### PR TITLE
chore(clip): Use upstream triu

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ num-traits = { version = "0.2.17", default-features = false }
 serde = { version = "1.0.192", default-features = false, features = ["derive", "alloc"] }
 
 [patch.crates-io]
-burn-wgpu = { git = "https://github.com/Tracel-AI/burn", rev = "60c24430c6d4685032d9e351a537eded7da1a35c" }
-burn = { git = "https://github.com/Tracel-AI/burn", rev = "60c24430c6d4685032d9e351a537eded7da1a35c" }
-burn-ndarray = { git = "https://github.com/Tracel-AI/burn", rev = "60c24430c6d4685032d9e351a537eded7da1a35c" }
-burn-tch = { git = "https://github.com/Tracel-AI/burn", rev = "60c24430c6d4685032d9e351a537eded7da1a35c" }
+burn-wgpu = { git = "https://github.com/Tracel-AI/burn", rev = "f0c75aa7482512b7c9a05f70da095a181ad4638e" }
+burn = { git = "https://github.com/Tracel-AI/burn", rev = "f0c75aa7482512b7c9a05f70da095a181ad4638e" }
+burn-ndarray = { git = "https://github.com/Tracel-AI/burn", rev = "f0c75aa7482512b7c9a05f70da095a181ad4638e" }
+burn-tch = { git = "https://github.com/Tracel-AI/burn", rev = "f0c75aa7482512b7c9a05f70da095a181ad4638e" }

--- a/src/transformers/clip.rs
+++ b/src/transformers/clip.rs
@@ -337,7 +337,7 @@ impl<B: Backend> ClipTextTransformer<B> {
         seq_len: usize,
         device: &B::Device,
     ) -> Tensor<B, 4> {
-        let mut mask: Tensor<B, 3> = Tensor::full_device([bsz, seq_len, seq_len], f32::MIN, device);
+        let mask: Tensor<B, 3> = Tensor::full_device([bsz, seq_len, seq_len], f32::MIN, device);
         mask.triu(1).unsqueeze_dim(1)
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,31 +1,6 @@
 use alloc::vec;
-use alloc::vec::Vec;
 use burn::tensor::backend::Backend;
-use burn::tensor::{Data, Element, ElementConversion, Numeric, Shape, Tensor};
-
-// https://github.com/huggingface/transformers/blob/674f750a57431222fa2832503a108df3badf1564/src/transformers/models/clip/modeling_clip.py#L678
-pub(crate) fn generate_causal_attention_mask<B: Backend>(
-    bsz: usize,
-    seq_len: usize,
-    device: &B::Device,
-) -> Tensor<B, 4> {
-    let mut mask_vec = Vec::with_capacity(seq_len * seq_len);
-    for i in 0..seq_len {
-        for j in 0..seq_len {
-            if j > i {
-                mask_vec.push(f32::MIN.elem());
-            } else {
-                mask_vec.push(0f32.elem());
-            }
-        }
-    }
-
-    let mask_data: Data<B::FloatElem, 2> = Data::new(mask_vec, Shape::new([seq_len, seq_len]));
-    Tensor::from_data_device(mask_data, device)
-        .unsqueeze::<3>()
-        .repeat(0, bsz)
-        .unsqueeze_dim(1)
-}
+use burn::tensor::{Element, Numeric, Tensor};
 
 pub(crate) fn pad_with_zeros<B, const D: usize, K>(
     tensor: Tensor<B, D, K>,
@@ -76,33 +51,7 @@ where
 mod tests {
     use super::*;
     use crate::TestBackend;
-    use burn::tensor::{backend::Backend, Data, Shape};
-
-    #[test]
-    fn test_build_causal_attention_mask() {
-        let device = <TestBackend as Backend>::Device::default();
-
-        let mask = generate_causal_attention_mask::<TestBackend>(2, 4, &device);
-        assert_eq!(mask.shape(), Shape::from([2, 1, 4, 4]));
-
-        mask.to_data().assert_approx_eq(
-            &Data::from([
-                [[
-                    [0.0000e0, f32::MIN, f32::MIN, f32::MIN],
-                    [0.0000e0, 0.0000e0, f32::MIN, f32::MIN],
-                    [0.0000e0, 0.0000e0, 0.0000e0, f32::MIN],
-                    [0.0000e0, 0.0000e0, 0.0000e0, 0.0000e0],
-                ]],
-                [[
-                    [0.0000e0, f32::MIN, f32::MIN, f32::MIN],
-                    [0.0000e0, 0.0000e0, f32::MIN, f32::MIN],
-                    [0.0000e0, 0.0000e0, 0.0000e0, f32::MIN],
-                    [0.0000e0, 0.0000e0, 0.0000e0, 0.0000e0],
-                ]],
-            ]),
-            3,
-        );
-    }
+    use burn::tensor::{Data, Shape};
 
     #[test]
     fn test_pad_with_zeros() {


### PR DESCRIPTION
Now that https://github.com/Tracel-AI/burn/pull/1002 has been merged, we can use the `triu` provided by Burn.