### PR TITLE
chore(ci): Enable problem matcher just in one flow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,6 +15,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
+        cache: false
         components: rustfmt
     - name: Run cargo fmt
       run: cargo fmt -- --check
@@ -52,7 +53,9 @@ jobs:
     - name: install rust
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
+        cache: false
         toolchain: ${{ matrix.rust }}
+        matcher: ${{ matrix.os == 'ubuntu-latest' && matrix.rust == 'stable' && matrix.feature == 'ndarray' }}
         rustflags: "" # Disable when we're ready
     - name: caching
       uses: Swatinem/rust-cache@v2
@@ -117,6 +120,8 @@ jobs:
       with:
         toolchain: ${{ matrix.rust }}
         target: ${{ matrix.target }}
+        cache: false
+        matcher: false
         rustflags: "" # Disable when we're ready
     - name: caching
       uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
This should avoid spamming PRs for every matrix permutation